### PR TITLE
fix: correct Vercel build command for monorepo deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,5 +3,5 @@
   "devCommand": "pnpm dev",
   "installCommand": "pnpm install",
   "framework": "nextjs",
-  "outputDirectory": "apps/web/.next"
+  "outputDirectory": ".next"
 }


### PR DESCRIPTION
Remove 'cd ../..' from buildCommand as Vercel runs commands from the
repository root. This was causing the build to fail and preventing
the generation of .next/routes-manifest.json file.