### PR TITLE
fix: prevent FK violation on task creation with stale JWT sessions

### DIFF
--- a/apps/web/src/app/api/auth/link/google/callback/route.ts
+++ b/apps/web/src/app/api/auth/link/google/callback/route.ts
@@ -143,6 +143,16 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(accountsUrl.toString())
   }
 
+  // Verify user still exists before creating the Account row
+  const user = await prisma.user.findUnique({
+    where: { id: linkData.userId },
+    select: { id: true },
+  })
+  if (!user) {
+    accountsUrl.searchParams.set('link_error', 'user_not_found')
+    return NextResponse.redirect(accountsUrl.toString())
+  }
+
   // Create new Account row linked to the current user
   await prisma.account.create({
     data: {

--- a/apps/web/src/app/dashboard/accounts/page.tsx
+++ b/apps/web/src/app/dashboard/accounts/page.tsx
@@ -15,7 +15,7 @@ interface Props {
 export default async function AccountsPage({ searchParams }: Props) {
   const session = await auth()
 
-  if (!session?.user) {
+  if (!session?.user?.id) {
     redirect('/auth/signin')
   }
 

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -8,8 +8,7 @@ export const dynamic = 'force-dynamic'
 export default async function Dashboard() {
   const session = await auth()
 
-  // Redirect to signin if not authenticated
-  if (!session?.user) {
+  if (!session?.user?.id) {
     redirect('/auth/signin')
   }
 

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -11,3 +11,18 @@ body {
   color: var(--foreground);
   background: var(--background);
 }
+
+@keyframes toast-slide-in {
+  from {
+    opacity: 0;
+    transform: translateX(100%);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+.animate-toast-in {
+  animation: toast-slide-in 0.2s ease-out;
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import { ToastProvider } from '@/components/toast/ToastContext'
 import './globals.css'
 
 export const metadata: Metadata = {
@@ -13,7 +14,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className="antialiased">{children}</body>
+      <body className="antialiased">
+        <ToastProvider>{children}</ToastProvider>
+      </body>
     </html>
   )
 }

--- a/apps/web/src/app/todo/page.tsx
+++ b/apps/web/src/app/todo/page.tsx
@@ -10,8 +10,9 @@ export const dynamic = 'force-dynamic'
 export default async function TodoPage() {
   const session = await auth()
 
-  // Redirect to signin if not authenticated
-  if (!session?.user) {
+  // Redirect to signin if not authenticated or session has no valid user ID
+  // (e.g. stale JWT after DB recreation)
+  if (!session?.user?.id) {
     redirect('/auth/signin')
   }
 

--- a/apps/web/src/components/tasks/TaskList.tsx
+++ b/apps/web/src/components/tasks/TaskList.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect } from 'react'
 import { TaskListItemComponent } from './TaskListItem'
 import { api } from '@/lib/api/client'
 import { CreateTaskDto, UpdateTaskDto, TaskResponseDto, type TaskDto } from '@/lib/dto/task.dto'
+import { useToast } from '@/components/toast/ToastContext'
 import type { TaskListItem } from '@prisma/client'
 
 interface Props {
@@ -15,6 +16,7 @@ export function TaskList({ initialTasks }: Props) {
   const [isCreating, setIsCreating] = useState(false)
   const [newTaskText, setNewTaskText] = useState('')
   const newTaskInputRef = useRef<HTMLInputElement>(null)
+  const { toast } = useToast()
 
   const handleComplete = async (id: string) => {
     try {
@@ -27,6 +29,7 @@ export function TaskList({ initialTasks }: Props) {
       setTasks(tasks.filter((t) => t.id !== id))
     } catch (error) {
       console.error('Failed to complete task:', error)
+      toast('Failed to complete task. Please try again.', { type: 'error' })
     }
   }
 
@@ -40,6 +43,7 @@ export function TaskList({ initialTasks }: Props) {
       setTasks(tasks.map((t) => (t.id === id ? response.task : t)))
     } catch (error) {
       console.error('Failed to update task:', error)
+      toast('Failed to update task. Please try again.', { type: 'error' })
     }
   }
 
@@ -57,6 +61,7 @@ export function TaskList({ initialTasks }: Props) {
       setIsCreating(false)
     } catch (error) {
       console.error('Failed to create task:', error)
+      toast('Failed to create task. Please try again.', { type: 'error' })
     }
   }
 

--- a/apps/web/src/components/toast/ToastContainer.tsx
+++ b/apps/web/src/components/toast/ToastContainer.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import type { Toast, ToastType } from './ToastContext'
+
+interface Props {
+  toasts: Toast[]
+  onDismiss: (id: string) => void
+}
+
+const iconByType: Record<ToastType, { path: string; color: string; bg: string; border: string }> = {
+  success: {
+    path: 'M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
+    color: 'text-green-400',
+    bg: 'bg-green-500/10',
+    border: 'border-green-500/30',
+  },
+  error: {
+    path: 'M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z',
+    color: 'text-red-400',
+    bg: 'bg-red-500/10',
+    border: 'border-red-500/30',
+  },
+  warning: {
+    path: 'M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126z',
+    color: 'text-yellow-400',
+    bg: 'bg-yellow-500/10',
+    border: 'border-yellow-500/30',
+  },
+  info: {
+    path: 'M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z',
+    color: 'text-blue-400',
+    bg: 'bg-blue-500/10',
+    border: 'border-blue-500/30',
+  },
+}
+
+function ToastItem({ toast, onDismiss }: { toast: Toast; onDismiss: () => void }) {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    if (toast.duration !== Infinity) {
+      timerRef.current = setTimeout(onDismiss, toast.duration)
+    }
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    }
+  }, [toast.duration, onDismiss])
+
+  const style = iconByType[toast.type]
+
+  return (
+    <div
+      role="alert"
+      className={`pointer-events-auto flex w-full max-w-sm items-start gap-3 rounded-lg border ${style.border} ${style.bg} p-4 shadow-lg backdrop-blur-sm animate-toast-in`}
+    >
+      <svg
+        className={`h-5 w-5 flex-shrink-0 ${style.color}`}
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth="1.5"
+        stroke="currentColor"
+        aria-hidden="true"
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" d={style.path} />
+      </svg>
+
+      <p className="flex-1 text-sm text-gray-100">{toast.message}</p>
+
+      <button
+        onClick={onDismiss}
+        className="-mr-1 -mt-1 flex-shrink-0 rounded p-1 text-gray-400 hover:text-gray-200"
+        aria-label="Dismiss"
+      >
+        <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" strokeWidth="2" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+  )
+}
+
+export function ToastContainer({ toasts, onDismiss }: Props) {
+  if (toasts.length === 0) return null
+
+  return (
+    <div
+      aria-live="polite"
+      className="pointer-events-none fixed bottom-0 right-0 z-50 flex flex-col-reverse gap-2 p-4"
+    >
+      {toasts.map((t) => (
+        <ToastItem key={t.id} toast={t} onDismiss={() => onDismiss(t.id)} />
+      ))}
+    </div>
+  )
+}

--- a/apps/web/src/components/toast/ToastContainer.tsx
+++ b/apps/web/src/components/toast/ToastContainer.tsx
@@ -52,7 +52,7 @@ function ToastItem({ toast, onDismiss }: { toast: Toast; onDismiss: () => void }
   return (
     <div
       role="alert"
-      className={`pointer-events-auto flex w-full max-w-sm items-start gap-3 rounded-lg border ${style.border} ${style.bg} p-4 shadow-lg backdrop-blur-sm animate-toast-in`}
+      className={`pointer-events-auto flex w-full max-w-sm items-start gap-3 rounded-lg border ${style.border} ${style.bg} animate-toast-in p-4 shadow-lg backdrop-blur-sm`}
     >
       <svg
         className={`h-5 w-5 flex-shrink-0 ${style.color}`}
@@ -72,7 +72,13 @@ function ToastItem({ toast, onDismiss }: { toast: Toast; onDismiss: () => void }
         className="-mr-1 -mt-1 flex-shrink-0 rounded p-1 text-gray-400 hover:text-gray-200"
         aria-label="Dismiss"
       >
-        <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" strokeWidth="2" stroke="currentColor">
+        <svg
+          className="h-4 w-4"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth="2"
+          stroke="currentColor"
+        >
           <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
         </svg>
       </button>

--- a/apps/web/src/components/toast/ToastContext.tsx
+++ b/apps/web/src/components/toast/ToastContext.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { createContext, useCallback, useContext, useState, type ReactNode } from 'react'
+import { ToastContainer } from './ToastContainer'
+
+export type ToastType = 'success' | 'error' | 'info' | 'warning'
+
+export interface ToastOptions {
+  /** Duration in ms before auto-dismiss. Set to `Infinity` to keep indefinitely. Default: 10000 */
+  duration?: number
+  type?: ToastType
+}
+
+export interface Toast {
+  id: string
+  message: string
+  type: ToastType
+  duration: number
+}
+
+interface ToastContextValue {
+  toast: (message: string, options?: ToastOptions) => void
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null)
+
+let nextId = 0
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([])
+
+  const addToast = useCallback((message: string, options?: ToastOptions) => {
+    const id = String(++nextId)
+    setToasts((prev) => [
+      ...prev,
+      {
+        id,
+        message,
+        type: options?.type ?? 'info',
+        duration: options?.duration ?? 10_000,
+      },
+    ])
+  }, [])
+
+  const removeToast = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id))
+  }, [])
+
+  return (
+    <ToastContext value={{ toast: addToast }}>
+      {children}
+      <ToastContainer toasts={toasts} onDismiss={removeToast} />
+    </ToastContext>
+  )
+}
+
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext)
+  if (!ctx) {
+    throw new Error('useToast must be used within a <ToastProvider>')
+  }
+  return ctx
+}

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -140,7 +140,7 @@ function getNextAuth() {
                   } catch (error) {
                     if (env.isDevelopment) {
                       await logInfo('Error refreshing tokens in JWT callback', {
-                        userId: token.id,
+                        userId: token.id as string | undefined,
                         error: error instanceof Error ? error.message : String(error),
                       })
                     }

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -132,7 +132,9 @@ function getNextAuth() {
                         select: { id: true },
                       })
                       if (!userExists) {
-                        console.warn(`User ${token.id} no longer exists in database, invalidating session`)
+                        console.warn(
+                          `User ${token.id} no longer exists in database, invalidating session`
+                        )
                         token.id = undefined
                       }
                       token.lastTokenRefresh = now


### PR DESCRIPTION
The session's user.id could reference a deleted User row (e.g. after DB
recreation), causing a foreign key constraint violation on task_list_item.

- Invalidate JWT session when token refresh finds no accounts and user
  no longer exists in the database
- Strengthen auth guards on all pages to check session.user.id (not just
  session.user), so stale sessions redirect to sign-in
- Catch Prisma P2003 FK errors in task creation with a clear message

https://claude.ai/code/session_012QVK4x8xyph6KYY6Cyxiid